### PR TITLE
Print current gecko commit when checking out

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -24,6 +24,7 @@ jobs:
           git-cinnabar --version
           cd ..
           git clone hg::https://hg.mozilla.org/mozilla-unified gecko && cd gecko
+          git log -1 --format='%H'
           ./mach --no-interactive bootstrap
           ./mach --no-interactive build
           ./mach storybook build


### PR DESCRIPTION
It's hard to tell why the moz-fieldset was removed in the last build. Print the currently checked out gecko revision before building so we at least have something to look for clues if it happens again